### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         # Java versions to run unit tests
-        java: [ '8', '8.0.192', '11', '11.0.3', '14', '17-ea' ]
+        java: [ '8', '8.0.192', '11', '11.0.3', '14' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
# [DRILL-XXXX](https://issues.apache.org/jira/browse/DRILL-XXXX): Using TCK Tested JDK builds of OpenJDK


## Description

The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. Also, I've included fixed versions for LTS releases as good practice.
Many software vendors and ISVs have customers that rely on fixed (major) JDK releases and often are frozen, and on occasion the latest build has broken systems in production. 

## Documentation
https://adoptopenjdk.net
While Temurin is the new successor to AdoptOpenJDK, it doesn't support all the versions available especially the ones specified in this project's workflows. 

## Testing
All GH action workflows shows green (pass).